### PR TITLE
Address failures in CI

### DIFF
--- a/run-warc-tests.sh
+++ b/run-warc-tests.sh
@@ -53,7 +53,7 @@ while IFS=: read ARCHIVE URL; do
     # Start the wayback server in tx1he background
     echo ""
     echo "Testing ${URL} from archive ${ARCHIVE}"
-    wayback --proxy "${ARCHIVE}" --port "${PORT}" > /dev/null 2>&1 &
+    wayback --proxy "${ARCHIVE}" --port "${PORT}" > wayback.log 2>&1 &
 
     # Wait for the server to start up
     while ! PID=$(lsof -Pi :"${PORT}" -t); do echo "Waiting for wayback server"; sleep 1; done

--- a/run-warc-tests.sh
+++ b/run-warc-tests.sh
@@ -44,6 +44,9 @@ cd "${SCRIPT_DIR}"
 echo "Creating output file ${OUTPUT}"
 echo "${CSV_COLUMNS}" > "${OUTPUT}"
 
+# Kill any wayback server that is currently running
+while PID=$(lsof -Pi :"${PORT}" -t); do echo "Killing ${PID}"; kill "${PID}"; sleep 1; done
+
 # Read the archives from the ARCHIVE file
 while IFS=: read ARCHIVE URL; do
 

--- a/run-warc-tests.sh
+++ b/run-warc-tests.sh
@@ -60,7 +60,10 @@ while IFS=: read ARCHIVE URL; do
 
     # Run a proxified servo on the URL, and save any WARC lines in the output file
     echo Running "${SERVO_CMD[@]}" "${URL}"
-    timeout 5m proxychains "${SERVO_CMD[@]}" "${URL}" | grep WARC | sed -e "s/WARC/${ARCHIVE}/" >> "${OUTPUT}"
+    timeout 5m proxychains "${SERVO_CMD[@]}" "${URL}" \
+	| grep WARC \
+	| sed -e "s/WARC/${ARCHIVE}/" >> "${OUTPUT}" \
+       || echo "Servo timed out"
 
     # Kill the wayback server
     kill "${PID}"


### PR DESCRIPTION
There are some failures running the performance tests in CI. My diagnosis for what's going on is...

* If Servo times out running one of the tests, the script exits (because we have `set -o errexit`). See, for example http://build.servo.org/builders/linux-nightly/builds/597/steps/test/logs/stdio - note that this exit does not kill the wayback server!

* The next time the nightly tests are run, the old wayback server is running (but in the wrong archive), which causes havoc.

So my proposed fix is

a) warn rather than exit if Servo times out, and
b) kill any old wayback servers that might be around before starting the script.
