### PR TITLE
Fix travis by using preinstalled shellcheck on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,5 @@ language: bash
 # Use container-based infrastructure for quicker build start-up
 sudo: false
 
-addons:
- apt:
-  sources:
-   - debian-sid    # Grab shellcheck from the Debian repo (o_O)
-  packages:
-   - shellcheck
-
 script:
  - bash -c 'shellcheck run-warc-tests.sh'
-
-matrix:
- fast_finish: true


### PR DESCRIPTION
Shellcheck is integrated into travis:

https://github.com/koalaman/shellcheck#travis-ci

Fixes the following gpg error https://travis-ci.org/servo/servo-warc-tests/builds/410196971